### PR TITLE
Adding visibility for class properties

### DIFF
--- a/accepted/PSR-3-logger-interface.md
+++ b/accepted/PSR-3-logger-interface.md
@@ -292,13 +292,13 @@ namespace Psr\Log;
  */
 class LogLevel
 {
-    const EMERGENCY = 'emergency';
-    const ALERT     = 'alert';
-    const CRITICAL  = 'critical';
-    const ERROR     = 'error';
-    const WARNING   = 'warning';
-    const NOTICE    = 'notice';
-    const INFO      = 'info';
-    const DEBUG     = 'debug';
+    public const EMERGENCY = 'emergency';
+    public const ALERT     = 'alert';
+    public const CRITICAL  = 'critical';
+    public const ERROR     = 'error';
+    public const WARNING   = 'warning';
+    public const NOTICE    = 'notice';
+    public const INFO      = 'info';
+    public const DEBUG     = 'debug';
 }
 ~~~


### PR DESCRIPTION
Adding visibility for properties in `class LogLevel`, for compliance with `PSR-2: 4.2. Properties`.
